### PR TITLE
Fix string handler for two level strings

### DIFF
--- a/FRIEND/FunctionSummary.cpp
+++ b/FRIEND/FunctionSummary.cpp
@@ -79,7 +79,7 @@ int	FunctionSummary::getSummaryHint(ea_t address, qstring &hint)
 				// some strings are nested two levels; they point to an offset just outside the function
 				// and then this offset points to the real string
 				auto ref2 = get_first_dref_from(ref);
-				if (!isASCII(ref) && ref != BADADDR)
+				if (!isASCII(getFlags(ref)) && ref2 != BADADDR)
 					ref = ref2;
 
 				if (isASCII(getFlags(ref)))

--- a/FRIEND/FunctionSummary.cpp
+++ b/FRIEND/FunctionSummary.cpp
@@ -76,6 +76,12 @@ int	FunctionSummary::getSummaryHint(ea_t address, qstring &hint)
 			auto ref = get_first_dref_from(fea);
 			if (ref != BADADDR)
 			{
+				// some strings are nested two levels; they point to an offset just outside the function
+				// and then this offset points to the real string
+				auto ref2 = get_first_dref_from(ref);
+				if (!isASCII(ref) && ref != BADADDR)
+					ref = ref2;
+
 				if (isASCII(getFlags(ref)))
 				{
 					RefInfo item;


### PR DESCRIPTION
This fixes the string summary when a string is nested two levels deep.
For example, a string might be referenced in a function:
00009384 010 LDR     R2, =aBinSystemctlIs ; "/bin/systemctl is-active %s

But then this actually points to
.text:0000941C C8 C5 00 00     off_941C        DCD aBinSystemctlIs     ; DATA XREF: systemctl_check_daemon_active+Cr

which then points to the real string:
.rodata:0000C5C8 2F 62 69 6E+    aBinSystemctlIs DCB "/bin/systemctl is-active %s",0

Now the plugin correctly handles these strings and displays them in the function summary.