### PR TITLE
Fix bugs and enhance IDA Pro 7.0 support on Windows

### DIFF
--- a/FRIEND/AArch32Extender.cpp
+++ b/FRIEND/AArch32Extender.cpp
@@ -732,7 +732,7 @@ bool AArch32Extender::getSystemRegisterName(ea_t address, char* nameBuffer, uint
 		
 		auto cpRegName = s_operandMap[opHash];
 		
-		qstrncat(nameBuffer, SCOLOR_ON, nameLength);
+		qstrncpy(nameBuffer, SCOLOR_ON, nameLength);
 		qstrncat(nameBuffer, SCOLOR_REG, nameLength);
 		qstrncat(nameBuffer, cpRegName, nameLength);
 		qstrncat(nameBuffer, SCOLOR_OFF, nameLength);

--- a/FRIEND/AArch64Extender.cpp
+++ b/FRIEND/AArch64Extender.cpp
@@ -106,7 +106,7 @@ bool AArch64Extender::getSystemRegisterName(ea_t address, char* nameBuffer, uint
 	tmp = cs_reg_name(m_capstoneHandle, RegisterInfo(type, insn_type, ops[sysRegIdx].reg));
 	BAIL_IF(tmp == nullptr, "[FRIEND]: unable to get register name for instruction at " PRINTF_ADDR " [ %.4X ]\n", address, rawInstruction);
 	
-	qstrncat(nameBuffer, SCOLOR_ON, nameLength);
+	qstrncpy(nameBuffer, SCOLOR_ON, nameLength);
 	qstrncat(nameBuffer, SCOLOR_REG, nameLength);
 	qstrncat(nameBuffer, tmp, nameLength);
 	qstrncat(nameBuffer, SCOLOR_OFF, nameLength);

--- a/FRIEND/FRIEND.cpp
+++ b/FRIEND/FRIEND.cpp
@@ -568,7 +568,8 @@ private:
 								delete[] e->x->helper;
 								e->x->helper = new char[kMaxElementNameLength];
 							#if _MSC_VER
-								strncpy_s(e->x->helper, "_WriteSystemReg", kMaxElementNameLength);
+								const char* func_name = "_WriteSystemReg";
+								strncpy_s(e->x->helper, kMaxElementNameLength, func_name, strlen(func_name));
 							#else
 								strncpy(e->x->helper, "_WriteSystemReg", kMaxElementNameLength);
 							#endif
@@ -602,7 +603,8 @@ private:
 								delete[] e->x->helper;
 								e->x->helper = new char[kMaxElementNameLength];
 							#if _MSC_VER
-								strncpy_s(e->x->helper, "_ReadSystemReg", kMaxElementNameLength);
+								const char* func_name = "_ReadSystemReg";
+								strncpy_s(e->x->helper, kMaxElementNameLength, func_name, strlen(func_name));
 							#else
 								strncpy(e->x->helper, "_ReadSystemReg", kMaxElementNameLength);
 							#endif

--- a/README.md
+++ b/README.md
@@ -96,6 +96,15 @@ $ cmake -G "Visual Studio 14 2015" [-DUSE_HEXRAYS=OFF] [-DUSE_IDA6_SDK=ON] ..
 $ msbuild FRIEND.sln /p:Configuration=Release
 ```
 
+x64 build instructions (tested for IDA Pro 7.0 on Windows 10 x64):
+```sh
+mkdir _build64
+cd _build64
+"%VS140COMNTOOLS%\..\..\VC\vcvarsall.bat" x64
+cmake -G "Visual Studio 14 2015 Win64" [-DUSE_HEXRAYS=OFF] [-DUSE_IDA6_SDK=ON] ..
+msbuild FRIEND.sln /p:Configuration=Release /p:Platform=X64 /m
+```
+
 ## Installation
 
 Copy the built binaries into the IDA Pro plugins directory. These are the default paths:
@@ -104,7 +113,7 @@ OS      | Plugin path
 --------|-------------------------------------------
 Linux   | `/opt/ida-X.X/plugins`
 macOS   | `/Applications/IDA Pro X.X/idabin/plugins`
-Windows | `%ProgramFiles(x86)%\IDA X.X\plugins`
+Windows | `%ProgramFiles(x86)%\IDA 6.X\plugins` or `%ProgramFiles%\IDA 7.X\plugins`
 
 ## Configuration files
 


### PR DESCRIPTION
Fix 2 general bugs:
- uninitialized memory usage (function `getSystemRegisterName` calls `strcat` analog for input string, but in function `hexRaysHook` that input string isn't zeroed after allocation and directly passed to the function `getSystemRegisterName`);
- fix type confusion when creating hint for nonstring element (`el->string` is valid only when `el->op == cot_str`).

Fix issues with compilation on Windows for IDA Pro 7.0:
- for MSVC generates error `C2660` for C++ version of function `strncpy_s` (replaced it by version with 4 arguments);
- IDA Pro is pure x64 application since version 7.0, so x64 compilation required (added instruction for Windows).